### PR TITLE
Fix: Corrected js-yaml load method call

### DIFF
--- a/src/spec/spec.ts
+++ b/src/spec/spec.ts
@@ -35,7 +35,7 @@ function readFile(filePath: string): Promise<string> {
 
 function parseFileContents(contents: string, path: string): OpenAPIObject {
   return /.ya?ml$/i.test(path)
-    ? YAML.safeLoad(contents) as OpenAPIObject
+    ? YAML.load(contents) as OpenAPIObject
     : JSON.parse(contents) as OpenAPIObject
 }
 


### PR DESCRIPTION
The generator exited with the error message "`Function yaml.safeLoad is removed in js-yaml 4. Use yaml.load instead, which is now safe by default.`" for me. I adjusted the method call accordingly.